### PR TITLE
fix: prevent usage of navigator in server runtime

### DIFF
--- a/src/lib/mobile.ts
+++ b/src/lib/mobile.ts
@@ -1,7 +1,6 @@
 import MobileDetect from 'mobile-detect';
 
-const mobileDetect = new MobileDetect(navigator.userAgent);
-
 export function isMobile(): boolean {
+	const mobileDetect = new MobileDetect(navigator.userAgent);
 	return mobileDetect.mobile() !== null;
 }


### PR DESCRIPTION
This causes ReferenceError: navigator is not defined.
Just importing this module executes top-level codes even in server runtime (Node.js) without navigator APIs.

The fix is moving this line into the function that shoould be called in the browser only.